### PR TITLE
Added Economy Commands

### DIFF
--- a/drp_core/admin/commands.lua
+++ b/drp_core/admin/commands.lua
@@ -149,3 +149,70 @@ end, false)
 --         end
 --     end
 -- end, false)
+
+RegisterCommand("addcash", function(source, args, raw)
+    local src = source
+    local player = GetPlayerData(src)
+    if player ~= false then
+        if DoesRankHavePerms(player.rank, "economy") then
+            if args[2] ~= nil then
+                TriggerEvent("DRP_Bank:AddCashMoney", tonumber(args[1]), tonumber(args[2])) 
+            else
+                print('test 2')
+                TriggerEvent("DRP_Bank:AddCashMoney", src, tonumber(args[1]))
+            end
+        else
+            TriggerClientEvent("DRP_Core:Error", src, "Admin System", tostring("You do not have permission to add money!"), 2500, false, "leftCenter")
+        end
+    end
+end, false) 
+
+RegisterCommand("removecash", function(source, args, raw)
+    local src = source
+    local player = GetPlayerData(src)
+    if player ~= false then
+        if DoesRankHavePerms(player.rank, "economy") then
+            if args[2] ~= nil then
+                TriggerEvent("DRP_Bank:RemoveCashMoney", tonumber(args[1]), tonumber(args[2])) 
+            else
+                TriggerEvent("DRP_Bank:RemoveCashMoney", src, tonumber(args[1]))
+            end
+        else
+            TriggerClientEvent("DRP_Core:Error", src, "Admin System", tostring("You do not have permission to add money!"), 2500, false, "leftCenter")
+        end
+    end
+end, false) 
+
+RegisterCommand("addbank", function(source, args, raw)
+    local src = source
+    local player = GetPlayerData(src)
+    if player ~= false then
+        if DoesRankHavePerms(player.rank, "economy") then
+            if args[2] ~= nil then
+                TriggerEvent("DRP_Bank:AddBankMoney", tonumber(args[1]), tonumber(args[2])) 
+            else
+                TriggerEvent("DRP_Bank:AddBankMoney", src, tonumber(args[1]))
+            end
+        else
+            TriggerClientEvent("DRP_Core:Error", src, "Admin System", tostring("You do not have permission to add money!"), 2500, false, "leftCenter")
+        end
+    end
+end, false) 
+
+RegisterCommand("removebank", function(source, args, raw)
+    local src = source
+    local player = GetPlayerData(src)
+    if player ~= false then
+        if DoesRankHavePerms(player.rank, "economy") then
+            if args[2] ~= nil then
+                TriggerEvent("DRP_Bank:RemoveBankMoney", tonumber(args[1]), tonumber(args[2])) 
+            else
+                TriggerEvent("DRP_Bank:RemoveBankMoney", src, tonumber(args[1]))
+            end
+        else
+            TriggerClientEvent("DRP_Core:Error", src, "Admin System", tostring("You do not have permission to add money!"), 2500, false, "leftCenter")
+        end
+    end
+end, false) 
+
+

--- a/drp_core/config.lua
+++ b/drp_core/config.lua
@@ -36,7 +36,7 @@ DRPCoreConfig.StaffRanks.ranks = {"user", "admin", "superadmin"}
 DRPCoreConfig.StaffRanks.perms = { -- This is what you need to reference too in the database for your rank :)
     ["User"] = {},
     ["admin"] = {"time", "weather", "adminaddcop", "heal"},
-    ["superadmin"] = {"time", "weather", "adminaddcop", "heal", "addgroup", "teleport"}
+    ["superadmin"] = {"time", "weather", "adminaddcop", "heal", "addgroup", "teleport", "economy"}
 }
 -- Edit these to your needs
 DRPCoreConfig.Locations = {


### PR DESCRIPTION
This PR adds 1 new permission for economy commands in the config labeled "economy" for superadmins and adds the following commands 

/addcash {amount} or /addcash {ID} {amount}
/removecash {amount} or /removecash {ID} {amount}
/addbank {amount} or /addbank {ID} {amount}
/removebank {amount} or /removebank {ID} {amount}