### PR TITLE
Security Push

### DIFF
--- a/DatabaseAPI/server.js
+++ b/DatabaseAPI/server.js
@@ -7,7 +7,7 @@ app.use(bodyParser.json());
 
 require("./routes")(app);
 
-app.listen(config.port, (req, res) => {
+app.listen(config.port, "localhost", (req, res) => {
     console.log("API Server Listening On Port: " + config.port)
 });
 


### PR DESCRIPTION
Restricting API calls from the localhost only.

You don't want external access to the API due to externalsql being a query API. Exposing it is dangerous to your database.