### PR TITLE
[WIP] feat(core): add client callbacks

### DIFF
--- a/drp_core/fxmanifest.lua
+++ b/drp_core/fxmanifest.lua
@@ -29,6 +29,7 @@ shared_script "shared/shared.lua"
 shared_script "worldSync/config.lua"
 shared_script "config.lua"
 shared_script "managers/networkcallbacks.lua"
+shared_script "managers/clientcallbacks.lua"
 shared_script "locales.lua"
 shared_script "managers/locales.lua"
 

--- a/drp_core/managers/clientcallbacks.lua
+++ b/drp_core/managers/clientcallbacks.lua
@@ -1,0 +1,92 @@
+if not IsDuplicityVersion() then
+    DRP.ClientCallbacks = {
+        Callbacks = {},
+        PendingCallbacks = {},
+        CallbackID = 0,
+
+        ---@param name string
+        ---@param handler fun(cb: fun(...: any), ...: any): void
+        RegisterCallback = function(name, handler)
+            DRP.ClientCallbacks.Callbacks[name] = {
+                handler = handler
+            }
+        end,
+
+        ---@param name string
+        ---@param id number
+        ---@param cb fun(...: any): void
+        ---@vararg any
+        TriggerCallback = function(name, id, cb, ...)
+            if type(cb) ~= "function" then
+                return
+            end
+            if DRP.ClientCallbacks.Callbacks[name] == nil then
+                cb(nil)
+                return
+            end
+
+            if type(DRP.ClientCallbacks.Callbacks[name].handler) ~= "function" then
+                cb(nil)
+                return
+            end
+
+            DRP.ClientCallbacks.Callbacks[name].handler(function(...)
+                cb(...)
+            end, ...)
+        end
+    }
+
+    RegisterNetEvent('drp:clientcb:trigger')
+    AddEventHandler('drp:clientcb:trigger', function(name, id, ...)
+        DRP.ClientCallbacks.TriggerCallback(name, id, function(...)
+            TriggerServerEvent('drp:clientcb:calledBack', id, ...)
+        end, ...)
+    end)
+
+    exports('RegisterClientCallback', function(name, handler)
+        DRP.ClientCallbacks.RegisterCallback(name, handler)
+    end)
+else
+    DRP.ClientCallbacksSv = {
+        CallbackID = 0,
+        PendingCallbacks = {},
+        ---@param target number
+        ---@param name string
+        ---@param cb fun(...: any): void
+        ---@vararg
+        TriggerClientCallback = function(target, name, cb, ...)
+            if type(cb) ~= "function" then return end
+            target = tonumber(target)
+            if type(target) ~= "number" then return end
+            if DRP.ClientCallbacksSv.CallbackID + 1 > 65565 then
+                DRP.ClientCallbacksSv.CallbackID = 0
+            end
+
+            DRP.ClientCallbacksSv.CallbackID = DRP.ClientCallbacksSv.CallbackID + 1
+            local tmpCallback = {
+                id = DRP.ClientCallbacksSv.CallbackID,
+                handler = cb,
+                source = target
+            }
+
+            table.insert(DRP.ClientCallbacksSv.PendingCallbacks, tmpCallback)
+            TriggerClientEvent('drp:clientcb:trigger', target, name, tmpCallback.id, ...)
+        end
+    }
+
+    RegisterServerEvent('drp:clientcb:calledBack')
+    AddEventHandler('drp:clientcb:calledBack', function(id, ...)
+        local _source = source
+        for k,v in pairs(DRP.ClientCallbacksSv.PendingCallbacks) do
+            if v.source == _source and v.id == id then
+                v.handler(...)
+                table.remove(DRP.ClientCallbacksSv.PendingCallbacks, k)
+            end
+        end
+    end)
+
+    exports('TriggerClientCallback', function(target, name, cb, ...)
+        DRP.ClientCallbacksSv.TriggerClientCallback(target, name, cb, ...)
+    end)
+end
+

--- a/drp_core/types.lua
+++ b/drp_core/types.lua
@@ -1,0 +1,15 @@
+_G.exports.drp_core = {
+    ---@param name string
+    ---@param handler fun(cb: fun(...: any): void): void
+    RegisterClientCallback = function(name, handler)
+
+    end,
+
+    ---@param target number
+    ---@param name string
+    ---@param cb fun(...: any): void
+    ---@vararg
+    TriggerClientCallback = function(target, name, cb, ...)
+
+    end
+}


### PR DESCRIPTION
This will add the ability to register callbacks on the client side, then trigger them from the server. It is a nifty thing I made a while ago, but never really put it anywhere. This is especially helpful when you need instant information from a particular client on the server side. 

A good use example of this is say that you would like information about a vehicle the player is in on the server side, you could simply register the client callback for it, then trigger it from the server

```lua
exports.drp_core:RegisterClientCallback('drp:getveh', function(cb)
    local veh = GetVehiclePedIsIn(PlayerPedId())
    cb(GetVehicleSteeringAngle(veh))
end)
```

Then on the server

```lua
RegisterCommand('geit', function(source, args, raw)
    local target = table.unpack(args)
    target = tonumber(target)
    exports.drp_core:TriggerClientCallback(1, 'drp:getveh', function(angle)
    print('the angle was', angle)
    end)
end)
```

Types for the exports have been created in `types.lua`. This file should not be loaded in the `fxmanifest` as it is just for editor intellisense.

This feature isn't guaranteed to be extremely performant and may have flaws. Please review and test, I think this is something many could find useful for various things in the future.