### PR TITLE
Removed deprecated resource

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -43,7 +43,6 @@ ensure sessionmanager
 ensure fivem
 ensure hardcap
 ensure rconlog
-ensure scoreboard
 
 #### DRP ####
 


### PR DESCRIPTION
Removed scoreboard resource from server.cfg, because It's deprecated and removed from the official citizenfx repository too.